### PR TITLE
Remove Reference to dead link

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,7 +9,6 @@
 
 ## Development Process
 
-* Task list: prioritized using cross-repo [Projects in GitHub](https://github.com/orgs/mozilla-lockbox/projects)
 * Daily standup: async but prompted by "geekbot" at 3 PM Mountain
 * All code in Git(Hub)
   * PR -> Review -> Merge (optimistic)


### PR DESCRIPTION
I was curious to see which things were being worked on as part of this effort but unfortunately the projects link is dead. Perhaps its worth getting rid of this link? Perhaps it would be better to update to where its being stored now?