### PR TITLE
Publish a test static file in .well-known directory

### DIFF
--- a/.well-known/test.txt
+++ b/.well-known/test.txt
@@ -1,0 +1,1 @@
+This is a test.

--- a/_config.yml
+++ b/_config.yml
@@ -8,3 +8,5 @@ theme: minima
 header_pages:
   - process.md
   - architecture/index.md
+
+include: [".well-known"]


### PR DESCRIPTION
Proof of concept. So long as we have the hidden (dot) directory in the config as an include, then it'll publish as-is.

Resolves #15

I confirmed this loads by running the `jekyll serve` locally and pulling up http://127.0.0.1:4000/.well-known/test.txt

![screen shot 2017-11-29 at 11 08 59 am](https://user-images.githubusercontent.com/49511/33391331-e1427a80-d4f5-11e7-9c9f-777a919fabb4.png)
