### PR TITLE
Add extension download callout box to home page

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -9,3 +9,23 @@ table th {
 table td {
   padding: 4px 24px 4px 0;
 }
+
+a.button-link {
+  display: block;
+  margin: .5em auto;
+  padding: 0.5em;
+  width: 12em;
+  color: white;
+  background-color: #717171;
+  border: 1px solid #717171;
+  border-radius: 4px;
+  text-align: center;
+}
+
+div.callout-box {
+  float: right;
+  width: 30%;
+  margin-left: 1em;
+  padding: 1em;
+  background-color: #f9f9fa;
+}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -28,4 +28,6 @@ div.callout-box {
   margin-left: 1em;
   padding: 1em;
   background-color: #f9f9fa;
+  border: 1px solid #717171;
+  text-align: center;
 }

--- a/index.md
+++ b/index.md
@@ -7,8 +7,8 @@ title: Lockbox
   <h4>Lockbox for Desktop</h4>
   <p>A simple stand-alone password manager you can secure with your
      Firefox Account.</p>
-  <a href="https://testpilot.firefox.com/files/lockbox@mozilla.com/latest"
-     class="button-link">Install Lockbox</a>
+  <a href="https://mozilla-lockbox.github.io/lockbox-extension/"
+     class="button-link">Get Lockbox</a>
 </div>
 
 This website is to gather documentation and details for Mozilla's experimental

--- a/index.md
+++ b/index.md
@@ -3,6 +3,14 @@ layout: page
 title: Lockbox
 ---
 
+<div class="callout-box">
+  <h4>Lockbox for Desktop</h4>
+  <p>A simple stand-alone password manager you can secure with your
+     Firefox Account.</p>
+  <a href="https://testpilot.firefox.com/files/lockbox@mozilla.com/latest"
+     class="button-link">Install Lockbox</a>
+</div>
+
 This website is to gather documentation and details for Mozilla's experimental
 [Lockbox product][website]. Lockbox will be the framework for us to test and
 quickly iterate on hypotheses (on desktop and mobile) without disrupting


### PR DESCRIPTION
Resolves #18 

This adds a callout box to the landing page. Here's how it looks:

![screen shot 2017-12-05 at 3 25 25 pm](https://user-images.githubusercontent.com/49511/33634179-8bb139dc-d9d0-11e7-985e-6d586ba251ad.png)

@sandysage Based on how the theme handles the top navigation links, there's not a quick and easy way for us to add navigation links to something that's not part of this site (eg: can link to the Architecture docs page because that page is in this repo, but a link to download from Test Pilot is not). Just to add that _one link_ would mean re-implementing the entire theme's header and I don't think that's worth it. Do you? 