### PR TITLE
chore: provide a landing page for OAuth redirects

### DIFF
--- a/fxa/ios-redirect.html
+++ b/fxa/ios-redirect.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Lockbox iOS :: FxA Redirect Landing</title>
+  </head>
+  <body>
+    <h1>Lockbox iOS :: FxA Redirect Landing</h1>
+    <p>This page is the landing page to finish FxA-based sign in for iOS.</p>
+  </body>
+</html>


### PR DESCRIPTION
Have a real (do nothing) page for OAuth authorization redirects.

Only iOS is required at this time.