### PR TITLE
Add placeholder page for android

### DIFF
--- a/fxa/android-redirect.html
+++ b/fxa/android-redirect.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Lockbox Android :: FxA Redirect Landing</title>
+  </head>
+  <body>
+    <h1>Lockbox Android :: FxA Redirect Landing</h1>
+    <p>This page is the landing page to finish FxA-based sign in for Android.</p>
+  </body>
+</html>


### PR DESCRIPTION
This is a placeholder page to assist with FxA redirects on Lockbox for Android.  It should help prevent "404" error pages on Lockbox Android.