### PR TITLE
Add anchor to top of FAQ to allow direct linking

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -3,6 +3,7 @@ layout: page
 title: FAQ
 ---
 
+<a id="top">
 ### What is Firefox Lockbox?
 
 Firefox Lockbox is an experimental product from Mozilla, the makers of Firefox. It’s an app for iPhone ([sign up to be notified when the Android app is available](https://goo.gl/forms/ZwLIfHSGLrYcM6k83)) that gives you access to passwords you’ve saved to Firefox.  


### PR DESCRIPTION
This way we can set our FAQ links to open lower on the page and show more content (less navigation).