### PR TITLE
Fix mozilla.org link in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <footer class="site-footer">
   <div class="wrapper">
-  <a href="mozilla.org" class="mozilla-link">
+  <a href="https://mozilla.org/" class="mozilla-link">
     <img src="{{relativeBase}}assets/images/mozilla.svg" alt="Mozilla" width="100" height="32" />
   </a>
   <div class="footer-links">


### PR DESCRIPTION
It's missing a protocol so was linking to https://lockbox.firefox.com/mozilla.org